### PR TITLE
Dockerfile that can run 'brownie test'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# run with:
+# docker build -f Dockerfile -t brownie .
+# docker run -v $PWD:/usr/src brownie brownie test
+
+FROM ubuntu:bionic
+WORKDIR /usr/src
+
+RUN  apt-get update
+
+RUN apt-get install -y python3.6 python3-pip python3-venv wget curl git
+RUN pip3 install wheel pip setuptools virtualenv
+
+# apt provided versions of solc doesn't have the version
+# we use so use this route to get our specific version
+# NB: py-solc only supports up to 0.4.X at the moment 
+ARG SOLC_VERSION=v0.4.24
+RUN wget --quiet --output-document /usr/local/bin/solc https://github.com/ethereum/solidity/releases/download/${SOLC_VERSION}/solc-static-linux \
+    && chmod a+x /usr/local/bin/solc
+
+RUN apt-get install -y npm nodejs
+RUN npm install -g ganache-cli
+
+RUN curl https://raw.githubusercontent.com/iamdefinitelyahuman/brownie/master/brownie-install.sh | sh
+
+# Fix UnicodeEncodeError error when running tests
+ENV PYTHONIOENCODING=utf-8

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ brownie console
 >>> run('simple')
 ```
 
+To use docker to run the tests in brownie:
+
+```bash
+docker build -f Dockerfile -t brownie .
+docker run -v $PWD:/usr/src brownie brownie test
+```
+
+
 This runs [deployments/simple.py](deployments/simple.py) which:
 
 * Deploys ``KYCRegistrar`` from ``accounts[0]``

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -2,7 +2,7 @@
 
 import random
 
-from lib.components.eth import VirtualMachineError
+from lib.components.transaction import VirtualMachineError
 
 NO_SETUP = True
 


### PR DESCRIPTION
Note two tests currently fail

* install specific solc version from main repos
* install ganache-cli using npm
* upadate README with docker run cmd