### PR TITLE
Update Dockerfile to include solidity compilers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
 # run with:
 # docker build -f Dockerfile -t brownie .
 # docker run -v $PWD:/usr/src brownie brownie test
+# If you need to update the version of brownie then add the --no-cache
+#  flag to the docker build command
 
 FROM ubuntu:bionic
 WORKDIR /usr/src
 
 RUN  apt-get update
 
-RUN apt-get install -y python3.6 python3-pip python3-venv wget curl git
+RUN apt-get install -y python3.6 python3-pip python3-venv wget curl git npm nodejs
 RUN pip3 install wheel pip setuptools virtualenv
 
-# apt provided versions of solc doesn't have the version
-# we use so use this route to get our specific version
-# NB: py-solc only supports up to 0.4.X at the moment 
-ARG SOLC_VERSION=v0.4.24
-RUN wget --quiet --output-document /usr/local/bin/solc https://github.com/ethereum/solidity/releases/download/${SOLC_VERSION}/solc-static-linux \
-    && chmod a+x /usr/local/bin/solc
-
-RUN apt-get install -y npm nodejs
 RUN npm install -g ganache-cli
 
 RUN curl https://raw.githubusercontent.com/iamdefinitelyahuman/brownie/master/brownie-install.sh | sh
+
+# Brownie installs compilers at runtime so ensure the updates are
+# in the compiled image so it doesn't do this every time
+RUN brownie init; true
+RUN brownie test
 
 # Fix UnicodeEncodeError error when running tests
 ENV PYTHONIOENCODING=utf-8


### PR DESCRIPTION
Take out the explicit install of the solc compiler and run brownie during the image build so py-solc installs the compilers