### PR TITLE
Update Dockerfile for brownie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
 # run with:
 # docker build -f Dockerfile -t brownie .
 # docker run -v $PWD:/usr/src brownie brownie test
+# If you need to update the version of brownie then add the --no-cache
+#  flag to the docker build command
 
 FROM ubuntu:bionic
 WORKDIR /usr/src
 
 RUN  apt-get update
 
-RUN apt-get install -y python3.6 python3-pip python3-venv wget curl git
+RUN apt-get install -y python3.6 python3-pip python3-venv wget curl git npm nodejs
 RUN pip3 install wheel pip setuptools virtualenv
 
-# apt provided versions of solc doesn't have the version
-# we use so use this route to get our specific version
-# NB: py-solc only supports up to 0.4.X at the moment 
-ARG SOLC_VERSION=v0.4.24
-RUN wget --quiet --output-document /usr/local/bin/solc https://github.com/ethereum/solidity/releases/download/${SOLC_VERSION}/solc-static-linux \
-    && chmod a+x /usr/local/bin/solc
-
-RUN apt-get install -y npm nodejs
-RUN npm install -g ganache-cli
+RUN npm install -g ganache-cli@6.2.5
 
 RUN curl https://raw.githubusercontent.com/iamdefinitelyahuman/brownie/master/brownie-install.sh | sh
+
+# Brownie installs compilers at runtime so ensure the updates are
+# in the compiled image so it doesn't do this every time
+RUN brownie init; true
+RUN brownie test
 
 # Fix UnicodeEncodeError error when running tests
 ENV PYTHONIOENCODING=utf-8

--- a/tests/brownie.py
+++ b/tests/brownie.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3
+
+from brownie import *
+from scripts.deploy_simple import main
+
+def setup():
+    main()
+    global issuer, token, a
+    issuer = IssuingEntity[0]
+    token = SecurityToken[0]
+    a = accounts
+
+
+def first_test():
+    '''transfer balance''' 
+    check.confirms(token.transfer, (a[2], 101), "Unable to send to account 2")
+    check.equal(token.balanceOf(a[2]), 101, "Wrong balance on account 2")
+
+def check_start_balance():
+    '''check balance has been reset in the next test''' 
+    check.equal(token.balanceOf(a[2]), 0, "Wrong starting balance on account 2")
+
+# peg your installed version of ganache-cli to 6.2.5 or this will fail
+def check_balance_after_transfer():
+    '''check balance increases correctly after transfer''' 
+    check.equal(token.balanceOf(a[2]), 0, "Wrong starting balance on account 2")
+    check.confirms(token.transfer, (a[2], 400), "Unable to send to account 2")
+    check.equal(token.balanceOf(a[2]), 400, "Wrong balance on account 2")


### PR DESCRIPTION
- Run brownie as part of build so compilers are installed
- Remove explicit install of solc in Dockerfile
- Pin ganache-cli@6.2.5
- Add tests/brownie.py to check EVM snapshot